### PR TITLE
Add more error handling

### DIFF
--- a/finder.py
+++ b/finder.py
@@ -20,17 +20,15 @@ def find_709_comps_in_file(filepath: Path):
     with filepath.open("r") as fh:
         try:
             codestr = fh.read()
-        except UnicodeDecodeError:
-            return [(0, "Not UTF-8 encoded.")]
+        except UnicodeDecodeError as e:
+            return [(0, f"Could not decode file with default encoding ({e}).")]
         return find_709_comps(codestr)
 
 
 def find_709_comps(codestr: str) -> list[tuple[int, str]]:
     try:
         tree = ast.parse(codestr)
-    except SyntaxError:
-        return [(0, "Unable to parse file.")]
-    except ValueError as e:
+    except (SyntaxError, ValueError) as e:
         return [(0, f"Unable to parse file ({e}).")]
     finder = CompFinder()
     try:

--- a/finder.py
+++ b/finder.py
@@ -13,7 +13,7 @@ def find_709_comps_in_files(path: Path):
         paths = [path]
     elif path.is_dir():
         paths = path.glob("**/*.py")
-    return {str(p): find_709_comps_in_file(p) for p in paths}
+    return {str(p): find_709_comps_in_file(p) for p in paths if p.is_file()}
 
 
 def find_709_comps_in_file(filepath: Path):

--- a/finder.py
+++ b/finder.py
@@ -33,7 +33,10 @@ def find_709_comps(codestr: str) -> list[tuple[int, str]]:
     except ValueError as e:
         return [(0, f"Unable to parse file ({e}).")]
     finder = CompFinder()
-    finder.visit(tree)
+    try:
+        finder.visit(tree)
+    except RecursionError as e:
+        return [(0, f"Recursion error ({e}).")]
     return finder.problems
 
 

--- a/finder.py
+++ b/finder.py
@@ -30,6 +30,8 @@ def find_709_comps(codestr: str) -> list[tuple[int, str]]:
         tree = ast.parse(codestr)
     except SyntaxError:
         return [(0, "Unable to parse file.")]
+    except ValueError as e:
+        return [(0, f"Unable to parse file ({e}).")]
     finder = CompFinder()
     finder.visit(tree)
     return finder.problems


### PR DESCRIPTION
I ran it on the [top 5k PyPI packages](https://dev.to/hugovk/how-to-search-5000-python-projects-31gk) (sdists downloaded 29th April) and needed to add some extra error handling.

(Also found a couple of potential PEP 709 bugs, will report in the [Discourse thread](https://discuss.python.org/t/pep-709-one-behavior-change-that-was-missed-in-the-pep/26691/12).)

The extra error handling needed for:

# ValueError: source code string cannot contain null bytes

```pytb
❯ p finder.py /Users/hugo/top-pypi/output/aaa-out
/Users/hugo/top-pypi/output/aaa-out
/Users/hugo/top-pypi/output/aaa-out/ruff-0.0.263/local_dependencies/ruff/resources/test/fixtures/pylint/invalid_characters.py
Traceback (most recent call last):
  File "/private/tmp/compfinder/finder.py", line 231, in <module>
    results.update(find_709_comps_in_files(Path(path)))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/compfinder/finder.py", line 21, in find_709_comps_in_files
    raise(e)
  File "/private/tmp/compfinder/finder.py", line 18, in find_709_comps_in_files
    find_709_comps_in_file(p)
  File "/private/tmp/compfinder/finder.py", line 32, in find_709_comps_in_file
    return find_709_comps(codestr)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/compfinder/finder.py", line 37, in find_709_comps
    tree = ast.parse(codestr)
           ^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/ast.py", line 50, in parse
    return compile(source, filename, mode, flags,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: source code string cannot contain null bytes
```

# IsADirectoryError: [Errno 21] Is a directory:

```pytb
Traceback (most recent call last):
  File "/private/tmp/compfinder/finder.py", line 231, in <module>
    results.update(find_709_comps_in_files(Path(path)))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/compfinder/finder.py", line 22, in find_709_comps_in_files
    return {str(p): find_709_comps_in_file(p) for p in paths}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/compfinder/finder.py", line 22, in <dictcomp>
    return {str(p): find_709_comps_in_file(p) for p in paths}
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/compfinder/finder.py", line 26, in find_709_comps_in_file
    with filepath.open("r") as fh:
         ^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/pathlib.py", line 1044, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
IsADirectoryError: [Errno 21] Is a directory: '/Users/hugo/top-pypi/output/aaa-out/metricflow-lite-0.130.2/metricflow/test/snapshots/test_sql_plan_render.py'
```

# RecursionError: maximum recursion depth exceeded

```pytb
Traceback (most recent call last):
  File "/private/tmp/compfinder/finder.py", line 22, in find_709_comps_in_files
    raise(e)
  File "/private/tmp/compfinder/finder.py", line 19, in find_709_comps_in_files
    find_709_comps_in_file(p)
  File "/private/tmp/compfinder/finder.py", line 32, in find_709_comps_in_file
    return find_709_comps(codestr)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/compfinder/finder.py", line 43, in find_709_comps
    finder.visit(tree)
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/ast.py", line 418, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/private/tmp/compfinder/finder.py", line 157, in visit_Module
    self.visit_in_scope(node, node.body)
  File "/private/tmp/compfinder/finder.py", line 126, in visit_in_scope
    self.visit(node)
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/ast.py", line 418, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/ast.py", line 428, in generic_visit
    self.visit(value)
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/ast.py", line 418, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
...
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/ast.py", line 428, in generic_visit
    self.visit(value)
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/ast.py", line 418, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded
```

Which came from 
`/Users/hugo/top-pypi/output/aaa-out/asttokens-2.2.1/tests/testdata/python3/astroid/joined_strings.py` and `/Users/hugo/top-pypi/output/aaa-out/asttokens-2.2.1/tests/testdata/python2/astroid/joined_strings.py`

